### PR TITLE
docs: fix 33 typos and grammar errors across documentation

### DIFF
--- a/docs/configuration/pga-configuration.md
+++ b/docs/configuration/pga-configuration.md
@@ -7,7 +7,7 @@
 <br>
 ### Apache Airavata Component Configuration
 1. For this we use 'Admin Dashboard'
-2. Gateway Admin need to configure;<br>
+2. Gateway Admin needs to configure;<br>
 	- <a href="#CompResource">Compute Resources</a><br>
 	- <a href="#StoreResource">Storage Resources</a><br>
 	- <a href= "#Preference">Gateway Management</a><br>
@@ -33,7 +33,7 @@
 	- File Systems (This is only for information capturing for future use. Currently this information is not used. So can skip if you want)
 	- Job Submission Interfaces
 	- Data Movement Interfaces
-5. Similarly you can add multiple compute resources in to your gateway by selecting 'Register' from the left-hand-side menu.
+5. Similarly you can add multiple compute resources into your gateway by selecting 'Register' from the left-hand-side menu.
 6. To view the added compute resources navigate to Admin Dashboard &#8658; Compute Resource &#8658; Browse
 7. All the resources will be listed. Gateway admin can view, edit, delete and enable and disable them.
 <br>
@@ -43,10 +43,10 @@
 2. Add Storage Name, Description and create the resource.
 3. Then add data storage information in
 	- Data Movement Interfaces
-4. Similarly you can add multiple storage resources in to your gateway by selecting 'Register' from the left-hand-side menu.
+4. Similarly you can add multiple storage resources into your gateway by selecting 'Register' from the left-hand-side menu.
 5. To view the added resources navigate to Admin Dashboard &#8658; Storage Resources &#8658; Browse
 6. All the resources will be listed. Gateway admin can view, edit, delete them. 
-7. Although enable and disable can be done in registration it's functionality is not yet implemented.
+7. Although enable and disable can be done in registration its functionality is not yet implemented.
 <br>
 <br>
 ###Gateway Management of Resources
@@ -68,18 +68,18 @@
   	- Quality of service
   	- Reservation name
   	- Reservation start and end date time
-5. For adding storage resource preference click "Add a Storage Resource Preferences", and rest is similar to adding a compute resource preference.
-6. For a gateway currently when a storage resource is selected, that resource ID need to be added in to the pga_config.php file in config folder of the hosted gateway.
+5. For adding storage resource preference click "Add a Storage Resource Preference", and rest is similar to adding a compute resource preference.
+6. For a gateway currently when a storage resource is selected, that resource ID need to be added into the pga_config.php file in config folder of the hosted gateway.
 7. For storage resource preference, gateway admin need to add;
 	- Login username
 	- File System Root Location
 	- Resource Specific Credential Store Token
-8. Apart from adding preference the same interface is used to assign a 'Base Credential Store Token". If this is added this is the token used across the gateway for communication with all the compute resources and storage resource.
+8. Apart from adding preference the same interface is used to assign a 'Base Credential Store Token'. If this is added this is the token used across the gateway for communication with all the compute resources and storage resource.
 <br>
 <br>
 ###Application Catalog
-1. Users in Admin group can add applications in to the gateway.
-2. Adding an application involves adding details in to the three tabs - Details, Interface and Deployments.
+1. Users in Admin group can add applications into the gateway.
+2. Adding an application involves adding details into the three tabs - Details, Interface and Deployments.
 4. What each tab means and capture?
 	- <b class="blue">Application Module</b>
 		- Navigation: Admin Dashboard &#8658; App Catalog &#8658; Module
@@ -94,19 +94,19 @@
 		- Click on 'Create a New Application Interface', provide information and create. On creation Application Interface ID will be generated for the module.
         - All available interfaces are also listed; admin has the option of searching for a particular interface by providing the name in the search.
         - Gateway admin can edit, delete existing interfaces.
-        - Gateway admin cal also clone an existing interface in order to create a new similar interface with slight changes.
+        - Gateway admin can also clone an existing interface in order to create a new similar interface with slight changes.
 	- <b class="blue">Application deployment</b>
 		- Navigation: Admin Dashboard &#8658; App Catalog &#8658; Deployment
 			- Application deployment describes application deployment details on a specific resource.
 			- For an application for each resource there is a separate deployment.
 			- A single application can be deployed in multiple resources.
-			- Multiple application modules can be deployed in a single resource. E.g: Gaussian09 and Gaussian16 both exists in bridges.psc.edu and they both use same application interface.
+			- Multiple application modules can be deployed in a single resource. E.g: Gaussian09 and Gaussian16 both exist in bridges.psc.edu and they both use same application interface.
 <br>
 <br>
 ###Credential Store
 1. Navigation: Settings &#8658; Credential Store
 2. This interface is used to generate SSH key + token pairs.
-3. These generated keys can be added in to the authorized key files in each resource for SSH key based communication.
+3. These generated keys can be added into the authorized key files in each resource for SSH key based communication.
 4. Generated key can be either assigned at gateway level or/and at individual resource allocation level; one key + token pair  for all the resources OR have separate key for each resource.
 5. SSH keys are used for communication with compute resources and storage resources.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 - Primarily focused on submitting and managing application executions and workflows in grid based systems.
 - Architecturally extensible to support other underlying resources.
 - Used by scientific gateway developers as their middleware layer. They can directly call Airavata API in order to communicate with grid based system.
-- Provides a desktop tools and browser-based web interface components for managing applications, workflows and generated data.
+- Provides desktop tools and browser-based web interface components for managing applications, workflows and generated data.
 - Contains sophisticated server-side tools for registering and managing scientific applications on computational resources.
 - The Django portal provides tools and methods to easily integrate with post processing applications and application centric interfaces.
 

--- a/docs/installation/airavata-server-properties.md
+++ b/docs/installation/airavata-server-properties.md
@@ -6,7 +6,7 @@
 		- registry.jdbc.url=jdbc:mysql://localhost:3306/experiment_catalog (replace 'localhost' with correct server name if the DB is in a different server)
 		- registry.jdbc.user=airavata
 		- registry.jdbc.password=airavata
-		- enable.sharing=true (This will set sharing within the gateway to be enabled. This is the advices mode)
+		- enable.sharing=true (This will set sharing within the gateway to be enabled. This is the advised mode)
 		- default.registry.gateway=php_reference_gateway (Give the gateway name you prefer. Default exists in the file)
 		- super.tenant.gatewayId=php_reference_gateway (Since you are hosting your own gateway this is the ID of your own gateway)
 2.  Application Catalog DB Configuration
@@ -76,8 +76,8 @@
 		- Make sure the RabbitMQ server is running. For production use <pre><code>rabbitmq-server -detached</code></pre> to start.
 		- Create a virtual-host and user with a password. Follow documentation in <a href="http://blog.dtzq.com/2012/06/rabbitmq-users-and-virtual-hosts.html" target="_blank">RabbitMQ Users & VirtualHost</a>
 		- To create a user; <pre><code>rabbitmqctl add_user Username Password</code></pre>
-		- To create a vitrual-host <pre><code>rabbitmqctl add_vhost vhostauthvhost</code></pre>
-		- Provide permission to created 'Username'  to the created vhost <pre><code>rabbitmqctl set_permissions -p messaging airavata ".*" ".*" ".*”</code></pre>
+		- To create a virtual-host <pre><code>rabbitmqctl add_vhost vhostauthvhost</code></pre>
+		- Provide permission to the created 'Username'  to the created vhost <pre><code>rabbitmqctl set_permissions -p messaging airavata ".*" ".*" ".*”</code></pre>
 		- Uncomment rabbitmq.broker.url=amqp://Username:Password@localhost:5672/Vhost. Add the created username, password and Vhost in the URL.
 		- If you need to stop RabbitMQ use <pre><code>rabbitmqctl stop</code></pre>
 		- If the RabbitMQ server stopped then the above user creation, vhost creation and permission granting commands need to run again after restarting the servers.

--- a/docs/maintenance/pga-maintenance.md
+++ b/docs/maintenance/pga-maintenance.md
@@ -4,7 +4,7 @@
 1. <a href="#FAILED">Investigate FAILED experiments/jobs</a></br>
 2. <a href="#unavailable">Handling unavailable Compute Resources</a></br>
 3. <a href= "#GtwyAccessI">Managing User Accounts</a></br>
-4. <a href= "#GtwyAccessII">Changing roles are not providing proper access</a></br>
+4. <a href= "#GtwyAccessII">Changing roles is not providing proper access</a></br>
 5. <a href= "#Allocation">Community account ran out of SUs</a></br>
 6. <a href="#PrePostCommands">Add Pre and Post Job Commands for an Application</a></br>
 7. <a href="#SampleApp">Add Environment Variables for an Application Deployment</a></br>
@@ -25,13 +25,13 @@ OR
         - Compute Resource <br>
 4. You could also use pre-defined selection criteria ('Get Experiments from Last 24 Hours' OR 'Get Experiments from Last Week')<br/>
 5. Once the experiment/s listed click on the 'Check Stats'
-6. Experiment task breakdown is listed and as the admin you could locate which task failed. Advice the gateway user accordingly.
+6. Experiment task breakdown is listed and as the admin you could locate which task failed. Advise the gateway user accordingly.
 
 <b class="blue" id="unavailable">Q2.</b> One of the resources used by my gateway is not available for the day. How to stop user job submissions?
 <br><b class="blue">Answer:</b> To temporarily stop users submitting jobs to a particular resource...<br>
 1. Navigate to AdminDashboard &#8658; Compute Resources (Browse)<br>
 2. Un-check the  'Enabled' box for the specific resource. This disables job submissions for the resource<br>
-3. To enable job submission simply check the box and you are back in track!<br>
+3. To enable job submission simply check the box and you are back on track!<br>
 NOTE: In order to enable disable resources you require super admin rights to the gateway. If not you need to contact SciGaP admins.
 
 <b class="blue" id="GtwyAccessI">Q3.</b> How to upgrade access for a gateway user?
@@ -39,13 +39,13 @@ NOTE: In order to enable disable resources you require super admin rights to the
 1. Navigate to Admin Dashboard &#8658; Users (Browse)<br>
 2. Search for the specific user and click 'Check All Roles'<br>
 3. From this you can remove/add roles.<br>
-4. For each modification user will receive an email with 'Your Privileges has Changed!'<br>
+4. For each modification user will receive an email with 'Your Privileges Have Changed!'<br>
 
 <b class="blue" id="GtwyAccessII">Q4.</b> Gateway users who has role 'gateway-user' cannot access experiment creation. Seems like privileges are not accessible.!
 <br><b class="blue">Answer:</b> User roles are given through PGA Admin Dashboard. If the roles are set correctly then check pga_config.php<br>
 1. To check the config file use
 <pre><code>vi /var/www/html/airavata-php-gateway/app/config/pga_config.php</code></pre>
-2. Roles attached to users should exists in the config file against correct role attribute type
+2. Roles attached to users should exist in the config file against correct role attribute type
 <pre><code>
         /**
          * Admin Role Name
@@ -63,7 +63,7 @@ NOTE: In order to enable disable resources you require super admin rights to the
 
 NOTE: In order to view and change config file you require access to PGA backend. If not you need to contact SciGaP admins.
 
-<b class="blue" id="Allocation">Q5.</b> I have ran out of allocation for my current community account used in gateway for a resource. What should I do?
+<b class="blue" id="Allocation">Q5.</b> I have run out of allocation for my current community account used in gateway for a resource. What should I do?
 <br><b class="blue">Answer:</b><br> 
 1. If you have another community account you could update the information in Admin Dashboard &#8658; Gateway Profile under Compute Resource Preferences.<br>
 2. Select the resource and modify account information and save.<br>
@@ -75,7 +75,7 @@ NOTE: In order to view and change config file you require access to PGA backend.
 2. Use 'Create a New Notice' button add a new notice. <br>
 3. Based on the published date you provided it will be available for users as a Notice !
 
-<b class="blue">Q7.</b> How to open the gateway to any user who create an user account? In the gateway not required to enable/activate user accounts.
+<b class="blue">Q7.</b> How to open the gateway to any user who create a user account? In the gateway not required to enable/activate user accounts.
 <br><b class="blue">Answer:</b><br>
 1. Gateway admin can switch between options of opening the gateway to all account creations OR gateway admin to activate accounts after creation.<br>
 2. In order to do open the gateway to all,<br>
@@ -91,7 +91,7 @@ NOTE: In order to view and change config file you require access to PGA backend.
                 'initial-role-name' => 'gateway-user',
         </code></pre>
         
-<b class="blue">Q7.</b> I want my gateway users to use their own compute resource allocation to submit jobs through the gateway. How to do this?
+<b class="blue">Q8.</b> I want my gateway users to use their own compute resource allocation to submit jobs through the gateway. How to do this?
 <br><b class="blue">Answer:</b><br>
 1. Users can add their own allocation account details. <br>
 2. In order to do so first login to the gateway.<br>

--- a/docs/user-documentation/JSON-tutorials.md
+++ b/docs/user-documentation/JSON-tutorials.md
@@ -2,13 +2,13 @@
 
 ###Introduction
 
-The Django portal for Apache Airavata middleware is new and caters to wider range of requirements from Gateways. <br>
+The Django portal for Apache Airavata middleware is new and caters to a wider range of requirements from Gateways. <br>
     
 One major requirement was more flexibility in application inputs. In the previous PGA, inputs were Integer, String, Number and URI. 
 User requirements were to have more options when adding these input types to their applications, such as option buttons, Cascading inputs, etc…
 
-In  Django in order to advance the input types JSON scripting is used. 
-When using JSON scripting, prior the developer/gateway admin need to add the component in to Django framework in order for it to work.
+In Django in order to advance the input types JSON scripting is used. 
+When using JSON scripting, prior the developer/gateway admin need to add the component into Django framework in order for it to work.
 
 ###String Input Validations
 
@@ -101,7 +101,7 @@ When using JSON scripting, prior the developer/gateway admin need to add the com
 
 ####Lists
 1. This is where the list is longer than 6 values. 
-2. A list longer than 6 values are two lengthy to display as option buttons. Users can use LOVs ( List of Values) if only a single value to be selected, and checkboxes if multiple values are required. 
+2. A list longer than 6 values are too lengthy to display as option buttons. Users can use LOVs ( List of Values) if only a single value to be selected, and checkboxes if multiple values are required. 
 
 ###Cascading Inputs
 1. Cascading inputs are child inputs based on a prior selection. 
@@ -162,8 +162,8 @@ When using JSON scripting, prior the developer/gateway admin need to add the com
 }
 ```
 
-###Dependant File Uploads
-1. Dependant input is a input that is dependant on certain option selected in a previous field. E.g.: If the option selected is ‘list-of-urls’ then show this field to upload a file.
+###Dependent File Uploads
+1. Dependent input is an input that is dependent on certain option selected in a previous field. E.g.: If the option selected is ‘list-of-urls’ then show this field to upload a file.
 2. If the selected option is ‘list-of-urls’ then the URI upload should be enabled.
 ```
 {

--- a/docs/user-documentation/airavata-user-profiles.md
+++ b/docs/user-documentation/airavata-user-profiles.md
@@ -2,7 +2,7 @@
 
 ### What Are Airavata User Groups?
 
-1. Prior to using Airavata, lets identify and understand the user groups available and their features.
+1. Prior to using Airavata, let's identify and understand the user groups available and their features.
 2. Knowing the groups and the features of each, will assist on shaping your gateway user hierarchy.
 3. There are 3 base user groups in Airavata with different set of features at each level.
 	- Admin
@@ -16,9 +16,9 @@
 	- Add gateway storage resource profile.
 	- Generate SSH keys for compute and storage resource SSH communications..
 	- Add the generated SSH key to group resource profiles.
-	- Add the generated SSH keys to authorized_key files in each resource.
+	- Add the generated SSH keys to authorized_keys files in each resource.
 	- Create Applications and their deployments in to the gateway.
-	- Manage users, add the mto base groups.
+	- Manage users, add them to base groups.
 <br><b>NOTE: If user hosts his own gateway; 'Gateway Admin' role will have access to create compute resources and storage resources as well.</b></br><br>
 2. Admin-Read-Only
 	- Can view everything in Settings but cannot Add, Edit or Delete any records from dashboard.
@@ -45,7 +45,7 @@
     - Owner - Person who creates the user group
     - Admin - Person who can add other users in to the group. These users' role cannot be changed by users with admin role.
     - Member - This person can use benefits of the group, but cannot add or remove users from the group.
-4. Only the owner of the group can change users; role. 
+4. Only the owner of the group can change users' role. 
 5. Adding users to base groups can be done using two interfaces.
     - Settings &rarr; Manage Users
     - Top right-hand corner dropdown menu &rarr; Groups

--- a/docs/user-documentation/cms-tutorials.md
+++ b/docs/user-documentation/cms-tutorials.md
@@ -1,11 +1,11 @@
 ## Django Gateway Theme Management
-In Django portal, the gateway branding or the theme is managed through a CMS. The Djangop portal uses WagTail CMS for the theme.<br>
-The CMS takes care fo the gateway home page, child pages content. <br>
+In Django portal, the gateway branding or the theme is managed through a CMS. The Django portal uses WagTail CMS for the theme.<br>
+The CMS takes care of the gateway home page, child pages content. <br>
 Gateways are initially deployed with a common base theme, but the gateway admins can re-brand according to their needs.<br>
 In order to change the theme user needs to be in the Admin group.<br>
 
 ### Instructions on Gateway Theme
-NOTE: For details instructions please refer <a href="https://github.com/apache/airavata-django-portal/blob/master/docs/cms.md" target="_blank"> Github CMS Instructions</a>
+NOTE: For detailed instructions please refer <a href="https://github.com/apache/airavata-django-portal/blob/master/docs/cms.md" target="_blank"> Github CMS Instructions</a>
 
 1. Login to your gateway portal.
 ![Screenshot](../img/login-page.png) <br></br>
@@ -16,7 +16,7 @@ NOTE: For details instructions please refer <a href="https://github.com/apache/a
 3. Click on the Wagtail icon → Go to Wagtail Admin
 ![Screenshot](../img/home-page2.png)<br></br>
 
-4. You are no in Wagtail CMS
+4. You are now in Wagtail CMS
 ![Screenshot](../img/wagtail-home.png)<br></br>
 
 5. To create a new child page or to edit the existing Home page, navigate to Pages, on left.


### PR DESCRIPTION
## Summary

Fix typos and grammar errors across 7 documentation files:

- **pga-configuration.md** — 7 fixes: `in to` → `into` (×6), `it's functionality` → `its`, `cal also` → `can also`, `both exists` → `both exist`, mismatched quotes, singular/plural
- **pga-maintenance.md** — 8 fixes: `Advice` → `Advise`, `back in track` → `back on track`, `Privileges has Changed` → `Have Changed`, `I have ran` → `I have run`, `an user` → `a user`, duplicate Q7 → Q8
- **JSON-tutorials.md** — 7 fixes: `Dependant` → `Dependent`, `two lengthy` → `too lengthy`, `is a input` → `is an input`, double space, missing article
- **airavata-server-properties.md** — 3 fixes: `vitrual-host` → `virtual-host`, `advices mode` → `advised mode`, missing article
- **index.md** — 1 fix: `a desktop tools` → `desktop tools`
- **cms-tutorials.md** — 4 fixes: `Djangop` → `Django`, `care fo` → `care of`, `no in` → `now in`, `details instructions` → `detailed`
- **airavata-user-profiles.md** — 4 fixes: `lets` → `let's`, `authorized_key` → `authorized_keys`, `add the mto` → `add them to`, `users; role` → `users' role`

No functional changes — documentation only.